### PR TITLE
Fixed agent logging, removed Xbootclasspath, minor formatting updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,20 @@ FROM glassfish:latest
 ENV INSPECTIT_VERSION 1.6.9.83
 ENV INSPECTIT_AGENT_HOME /opt/agent
 
+# download agent and prepare
 RUN wget https://github.com/inspectIT/inspectIT/releases/download/${INSPECTIT_VERSION}/inspectit-agent-sun1.5-${INSPECTIT_VERSION}.zip -q \
-      && unzip inspectit-agent-sun1.5-${INSPECTIT_VERSION}.zip -d /opt \
-      && apt-get clean \
-      && rm -rf /var/lib/apt \
-      && rm -f inspectit-agent-sun1.5-${INSPECTIT_VERSION}.zip
+ && unzip inspectit-agent-sun1.5-${INSPECTIT_VERSION}.zip -d /opt \
+ && apt-get clean \
+ && rm -rf /var/lib/apt \
+ && rm -f inspectit-agent-sun1.5-${INSPECTIT_VERSION}.zip
 
-RUN ln -s /opt/agent/inspectit-agent.jar glassfish/domains/domain1/lib/ext/
+# alter the configuration for the domain to include inspectIT options
+RUN sed -i "s#\(</java-config>\)#<jvm-options>-javaagent:\${INSPECTIT_AGENT_HOME}/inspectit-agent.jar</jvm-options>\1#" glassfish/domains/domain1/config/domain.xml \
+ && sed -i "s#\(</java-config>\)#<jvm-options>-Dinspectit.repository=_CMR_ADDR_:_CMR_PORT_</jvm-options>\1#" glassfish/domains/domain1/config/domain.xml \
+ && sed -i "s#\(</java-config>\)#<jvm-options>-Dinspectit.agent.name=_AGENT_NAME_</jvm-options>\1#" glassfish/domains/domain1/config/domain.xml \
+ && sed -i "s/org\.netbeans\.lib\.profiler, org\.netbeans\.lib\.profiler.*/org\.netbeans\.lib\.profiler, org\.netbeans\.lib\.profiler\.\*, rocks\.inspectit\.\*/" glassfish/config/osgi.properties
 
-RUN sed -i "s#\(</java-config>\)#<jvm-options>-Xbootclasspath/p:\${com\.sun\.aas\.instanceRoot}/lib/ext/inspectit-agent\.jar</jvm-options>\1#" glassfish/domains/domain1/config/domain.xml \
-	&& sed -i "s#\(</java-config>\)#<jvm-options>-javaagent:\${com\.sun\.aas\.instanceRoot}/lib/ext/inspectit-agent.jar</jvm-options>\1#" glassfish/domains/domain1/config/domain.xml \
-	&& sed -i "s#\(</java-config>\)#<jvm-options>-Dinspectit.repository=_CMR_ADDR_:_CMR_PORT_</jvm-options>\1#" glassfish/domains/domain1/config/domain.xml \
-  && sed -i "s#\(</java-config>\)#<jvm-options>-Dinspectit.agent.name=_AGENT_NAME_</jvm-options>\1#" glassfish/domains/domain1/config/domain.xml \
-        && sed -i "s/org\.netbeans\.lib\.profiler, org\.netbeans\.lib\.profiler.*/org\.netbeans\.lib\.profiler, org\.netbeans\.lib\.profiler\.\*, rocks\.inspectit\.\*/" glassfish/config/osgi.properties
-
+# copy start script
 COPY run-with-inspectit.sh /run-with-inspectit.sh
 
 CMD /run-with-inspectit.sh

--- a/run-with-inspectit.sh
+++ b/run-with-inspectit.sh
@@ -2,19 +2,18 @@
 
 CMR_ADDR=${INSPECTIT_CMR_ADDR:-cmr}
 CMR_PORT=${INSPECTIT_CMR_PORT:-9070}
-
+AGENT_NAME=${AGENT_NAME:-$HOSTNAME}
 
 if ([ -z $INSPECTIT_CMR_ADDR ] || [ -z $INSPECTIT_CMR_PORT ]) && ([ -z $CMR_PORT_9070_TCP_ADDR ] || [ -z $CMR_PORT_9070_TCP_PORT ]); then
         echo "[ERROR] No inspectIT CMR configured! Please read our README"
         exit 1
 fi
 
-AGENT_NAME=${AGENT_NAME:-$HOSTNAME}
-RUN_SCRIPT=${GLASSFISH_HOME}/glassfish/domains/domain1/config/domain.xml
-
-sed -i -- "s/_CMR_ADDR_/$CMR_ADDR/g" $RUN_SCRIPT
-sed -i -- "s/_CMR_PORT_/$CMR_PORT/g" $RUN_SCRIPT
-sed -i -- "s/_AGENT_NAME_/$AGENT_NAME/g" $RUN_SCRIPT
+# Update inspectIT options in the configuration file
+CONFIGURATION_FILE=${GLASSFISH_HOME}/glassfish/domains/domain1/config/domain.xml
+sed -i -- "s/_CMR_ADDR_/$CMR_ADDR/g" $CONFIGURATION_FILE
+sed -i -- "s/_CMR_PORT_/$CMR_PORT/g" $CONFIGURATION_FILE
+sed -i -- "s/_AGENT_NAME_/$AGENT_NAME/g" $CONFIGURATION_FILE
 
 # Version check
 if ([[ -n $INSPECTIT_VERSION && -n $CMR_ENV_INSPECTIT_VERSION && $INSPECTIT_VERSION != $CMR_ENV_INSPECTIT_VERSION ]]); then


### PR DESCRIPTION
@andreasreinhardt @mariomann  @matthias-huber Can you have a look on these change. This fixes the logging of the agent, as it could not find the logging-config.xml as it was not in the same folder with agent jar. I am using simply now the agent jar from agent location and this works well (no link to the _lib/etx/_ folder). Also I added some formatting updates so that commands are more readable.
